### PR TITLE
Add indexers to Point3d and Vector3d.

### DIFF
--- a/src/GShark/Geometry/Point3d.cs
+++ b/src/GShark/Geometry/Point3d.cs
@@ -331,11 +331,29 @@ namespace GShark.Geometry
         /// </summary>
         public double Z { get => _z; set => _z = value; }
 
-
         /// <summary>
         /// Each coordinate of the point must pass the <see cref="GeoSharpMath.IsValidDouble"/> test.
         /// </summary>
         public bool IsValid => GeoSharpMath.IsValidDouble(_x) && GeoSharpMath.IsValidDouble(_y) && GeoSharpMath.IsValidDouble(_z);
+
+        //Indexer to allow access to properties as array.
+        public double this[int i]
+        {
+            get
+            {
+                if (i < 0 || i > 2) throw new IndexOutOfRangeException();
+                if (i == 0) return _x;
+                if (i == 1) return _y;
+                return _z;
+            }
+            set
+            {
+                if (i < 0 || i > 2) throw new IndexOutOfRangeException();
+                if (i == 0) _x = value;
+                if (i == 1) _y = value;
+                _z = value;
+            }
+        }
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is a <see cref="Point3d"/> and has the same values as the present point.

--- a/src/GShark/Geometry/Vector3d.cs
+++ b/src/GShark/Geometry/Vector3d.cs
@@ -416,6 +416,24 @@ namespace GShark.Geometry
         /// </summary>
         public bool IsZero => (_x == 0.0 && _y == 0.0 && _z == 0.0);
 
+        //Indexer to allow access to properties as array.
+        public double this[int i]
+        {
+            get
+            {
+                if (i < 0 || i > 2) throw new ArgumentOutOfRangeException();
+                if (i == 0) return _x;
+                if (i == 1) return _y;
+                return _z;
+            }
+            set
+            {
+                if (i < 0 || i > 2) throw new ArgumentOutOfRangeException();
+                if (i == 0) _x = value;
+                if (i == 1) _y = value;
+                _z = value;
+            }
+        }
 
         /// <summary>
         /// Determines whether the specified System.Object is a Vector3d and has the same values as the present vector.


### PR DESCRIPTION
- Point3d and Vector3d can be treated as arrays when/if necessary.
- Allows for easy replacement of Vector3 class.