### PR TITLE
Add "segment at length" and "segment at" method in polycurve

### DIFF
--- a/src/GShark.Test.XUnit/Geometry/PolyCurveTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/PolyCurveTests.cs
@@ -81,5 +81,38 @@ namespace GShark.Test.XUnit.Geometry
             // Assert
             length.Should().BeApproximately(expectedLength, GSharkMath.MinTolerance);
         }
+
+        [Theory]
+        [InlineData(23.769824635278, 2)]
+        [InlineData(21.269824635278, 1)]
+        [InlineData(20, 0)]
+        public void It_Returns_The_Segment_At_Length(double length, int idx)
+		{
+            //Arrange
+            NurbsBase curve = _polycurve.Segments[idx];
+
+            //Act
+            NurbsBase result = _polycurve.SegmentAtLength(length);
+
+            //Assert
+            result.Should().BeSameAs(curve);
+        }
+
+        [Theory]
+        [InlineData(23.769824635278, 2)]
+        [InlineData(21.269824635278, 1)]
+        [InlineData(20, 0)]
+        public void It_Returns_The_Segment_At_Parameter(double length, int idx)
+        {
+            //Arrange
+            NurbsBase curve = _polycurve.Segments[idx];
+            double para = _polycurve.ParameterAtLength(length);
+
+            //Act
+            NurbsBase result = _polycurve.SegmentAt(para);
+
+            //Assert
+            result.Should().BeSameAs(curve);
+        }
     }
 }

--- a/src/GShark/Geometry/PolyCurve.cs
+++ b/src/GShark/Geometry/PolyCurve.cs
@@ -97,6 +97,87 @@ namespace GShark.Geometry
         public List<NurbsBase> Segments => _segments;
 
         /// <summary>
+        /// Return the segment at Length in PolyCurve
+        /// </summary>
+        /// <param name="polyCurve"></param>
+        /// <param name="length"></param>
+        /// <returns></returns>
+        public NurbsBase SegmentAtLength(double length)
+        {
+            NurbsBase segment = null;
+            if (_segments.Count() > 0 && length <= this.Length)
+            {
+                if (_segments.Count() > 1)
+                {
+                    double temp = 0;
+                    foreach (NurbsBase curve in _segments)
+                    {
+                        double cLength = curve.Length + temp;
+                        if (length > temp && length < cLength)
+                        {
+                            segment = curve;
+                            break;
+                        }
+                        temp = cLength;
+                    }
+                }
+                else
+                {
+                    segment = _segments[0];
+                }
+            }
+            else
+            {
+                //return the last segment
+                segment = _segments[_segments.Count() - 1];
+            }
+
+            return segment;
+        }
+
+
+        /// <summary>
+        /// Return the segment at Length in PolyCurve
+        /// </summary>
+        /// <param name="polyCurve"></param>
+        /// <param name="length"></param>
+        /// <returns></returns>
+        public NurbsBase SegmentAt(double t)
+        {
+            NurbsBase segment = null;
+            double length = this.LengthAt(t);
+
+            if (_segments.Count() > 0 && length <= this.Length)
+            {
+                if (_segments.Count() > 1)
+                {
+                    double temp = 0;
+                    foreach (NurbsBase curve in _segments)
+                    {
+                        double cLength = curve.Length + temp;
+                        if (length > temp && length < cLength)
+                        {
+                            segment = curve;
+                            break;
+                        }
+                        temp = cLength;
+                    }
+                }
+                else
+                {
+                    segment = _segments[0];
+                }
+            }
+            else
+            {
+                //return the last segment
+                segment = _segments[_segments.Count() - 1];
+            }
+
+            return segment;
+        }
+
+        /// <summary>
         /// Defines the NURBS form of the polyline.
         /// </summary>
         private void ToNurbsForm()

--- a/src/GShark/Geometry/PolyCurve.cs
+++ b/src/GShark/Geometry/PolyCurve.cs
@@ -146,34 +146,7 @@ namespace GShark.Geometry
         {
             NurbsBase segment = null;
             double length = this.LengthAt(t);
-
-            if (_segments.Count() > 0 && length <= this.Length)
-            {
-                if (_segments.Count() > 1)
-                {
-                    double temp = 0;
-                    foreach (NurbsBase curve in _segments)
-                    {
-                        double cLength = curve.Length + temp;
-                        if (length > temp && length < cLength)
-                        {
-                            segment = curve;
-                            break;
-                        }
-                        temp = cLength;
-                    }
-                }
-                else
-                {
-                    segment = _segments[0];
-                }
-            }
-            else
-            {
-                //return the last segment
-                segment = _segments[_segments.Count() - 1];
-            }
-
+            segment = this.SegmentAtLength(length);
             return segment;
         }
 


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

### Description
Add SegmentAtLength and SegmentAt for PolyCurve class;


This PR [adds/removes/fixes/replaces] this [feature/bug/etc]. 
This two functions return the segment at chainage or at parameter. 

### Related Tickets & Documents
Fixes #349 
https://github.com/GSharker/G-Shark/issues/349
Fixes #350 
https://github.com/GSharker/G-Shark/issues/350

### Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 docs
- [ ] 🙅 no documentation needed
