### PR TITLE
Plane bug

### DIFF
--- a/src/GShark.Test.XUnit/Geometry/PlaneTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/PlaneTests.cs
@@ -66,7 +66,23 @@ namespace GShark.Test.XUnit.Geometry
             func.Should().Throw<Exception>()
                 .WithMessage("Plane cannot be created, the tree points must not be collinear");
         }
+        [Fact]
+        public void It_Creates_A_Plane_By_Two_Directions_And_Point()
+        {
+            // Arrange
+            Vector3 direction1 = Vector3.XAxis * 5;
+            Vector3 direction2 = Vector3.XAxis + Vector3.YAxis;
+            Point3 origin = new Point3();
 
+            // Act
+            Plane plane = new Plane(origin, direction1, direction2);
+
+            // Assert
+            plane.Origin.Equals(origin).Should().BeTrue();
+            plane.XAxis.EpsilonEquals(Vector3.XAxis, GSharkMath.MaxTolerance).Should().BeTrue();
+            plane.YAxis.EpsilonEquals(Vector3.YAxis, GSharkMath.MaxTolerance).Should().BeTrue();
+            plane.ZAxis.EpsilonEquals(Vector3.ZAxis, GSharkMath.MaxTolerance).Should().BeTrue();
+        }
         [Fact]
         public void It_Creates_A_Plane_By_Three_Points()
         {

--- a/src/GShark.Test.XUnit/Geometry/PlaneTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/PlaneTests.cs
@@ -69,7 +69,8 @@ namespace GShark.Test.XUnit.Geometry
         [Fact]
         public void It_Creates_A_Plane_By_Two_Directions_And_Point()
         {
-            // Arrange
+            // Arrange (Creating a plane with one direction along world X and the other direction along the
+            // the vector (1, 1)
             Vector3 direction1 = Vector3.XAxis * 5;
             Vector3 direction2 = Vector3.XAxis + Vector3.YAxis;
             Point3 origin = new Point3();

--- a/src/GShark/Geometry/Plane.cs
+++ b/src/GShark/Geometry/Plane.cs
@@ -59,9 +59,18 @@ namespace GShark.Geometry
         /// <param name="yDirection">Y direction.</param>
         public Plane(Point3 origin, Vector3 xDirection, Vector3 yDirection)
         {
+            if (Math.Abs(Vector3.VectorAngle(xDirection, yDirection)) < GSharkMath.AngleTolerance)
+                throw new Exception("Plane cannot be created. The direction vectors are parallel");
             Origin = origin;
-            XAxis = xDirection.IsUnitVector ? xDirection : xDirection.Unitize();
-            YAxis = yDirection.IsUnitVector ? yDirection : yDirection.Unitize();
+            // Unitizing the directions
+            Vector3 unitDir1 = xDirection.IsUnitVector ? xDirection : xDirection.Unitize();
+            Vector3 unitDir2 = yDirection.IsUnitVector ? yDirection : yDirection.Unitize();
+            // Xaxis
+            XAxis = unitDir1;
+            // Zaxis
+            Vector3 unitZ = Vector3.CrossProduct(unitDir1, unitDir2);
+            // Yaxis (Since in a right handed coordinate system, Yvec = Zvec X Xvec
+            YAxis = (Vector3.CrossProduct(unitZ, XAxis)).Unitize();
         }
 
         /// <summary>


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

### Description

This PR fixes the bug that was present in one of the Plane's constructors which took in a point and two direction vectors. The constructor now computes the orthogonal vectors which would define the X-axis and the Y-axis of the plane considering the first input direction to be the X-axis. 
Although there were already three test cases that that referenced this constructor, another test case is added which is dedicated for this particular constructor.

### Related Tickets & Documents
This PR Fixes #377 

### Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 docs
- [X] 🙅 no documentation needed
