### PR TITLE
ICurve implemented

### DIFF
--- a/src/GShark.Test.XUnit/Geometry/TransformTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/TransformTests.cs
@@ -1,0 +1,69 @@
+﻿using FluentAssertions;
+using GShark.Core;
+using GShark.Geometry;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GShark.Test.XUnit.Geometry
+{
+    public class TransformTests
+    {
+        private readonly ITestOutputHelper _testOutput;
+        private readonly Arc _arc;
+        private readonly Line _line;
+        private readonly NurbsCurve _curve;
+        private readonly Circle _circle;
+        private readonly Point3 _pt1;
+        private readonly Point3 _pt2;
+        private readonly Point3 _pt3;
+
+        public TransformTests(ITestOutputHelper testOutput)
+        {
+            _testOutput = testOutput;
+
+            #region example
+            _pt1 = new Point3(74.264416, 36.39316, -1.884313);
+            _pt2 = new Point3(97.679126, 13.940616, 3.812853);
+            _pt3 = new Point3(100.92443, 30.599893, -0.585116);
+
+            // Initializes an arc by plane, radius and angle.
+            _arc = new Arc(_pt1, _pt2, _pt3);
+
+            // Initializes a circle by 3 points.
+            _circle = new Circle(_pt1, _pt2, _pt3);
+
+            // Initializes a line 
+            _line = new Line(_pt1, _pt2);
+
+            // Initializes a curve
+            _curve = new NurbsCurve(new List<Point3>() { _pt1, _pt2, _pt3 }, 2);
+            #endregion
+        }
+
+        [Fact]
+        public void It_Returns_A_List_Of_Transformed_NurbsBase()
+        {
+            // Arrange
+            List<NurbsBase> geometries = new List<NurbsBase>() { _arc, _line, _curve, _circle};
+            var transform = Transform.Translation(new Vector3(1, 0, 0));
+
+            var expectedArc = new Arc(_pt1.Transform(transform), _pt2.Transform(transform), _pt3.Transform(transform));
+            var expectedCircle = new Circle(_pt1.Transform(transform), _pt2.Transform(transform), _pt3.Transform(transform));
+            var expectedLine = new Line(_pt1.Transform(transform), _pt2.Transform(transform));
+            var expectedCurve = new NurbsCurve(new List<Point3>() { _pt1.Transform(transform), _pt2.Transform(transform), _pt3.Transform(transform) }, 2);
+            List<NurbsBase> expectedGeometries = new List<NurbsBase>() { expectedArc, expectedLine, expectedCurve, expectedCircle };
+
+            // Act
+            var result = geometries.Select(geometry=> geometry.Transform(transform)).ToList();
+
+            // Assert
+            for (int i = 0; i < 4; i++)
+            {
+                result[i].StartPoint.EpsilonEquals(expectedGeometries[i].StartPoint, GSharkMath.MaxTolerance).Should().BeTrue();
+                result[i].EndPoint.EpsilonEquals(expectedGeometries[i].EndPoint, GSharkMath.MaxTolerance).Should().BeTrue();
+            }
+        }
+    }
+}

--- a/src/GShark/Geometry/Arc.cs
+++ b/src/GShark/Geometry/Arc.cs
@@ -13,7 +13,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Geometry/ArcTests.cs?name=example)]
     /// </example>
-    public class Arc : Circle, IEquatable<Arc>, ITransformable<Arc>
+    public class Arc : Circle, ICurve<Arc>
     {
         /// <summary>
         /// Initializes an arc from a plane, a radius and an angle domain expressed as an interval in radians.

--- a/src/GShark/Geometry/Arc.cs
+++ b/src/GShark/Geometry/Arc.cs
@@ -13,7 +13,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Geometry/ArcTests.cs?name=example)]
     /// </example>
-    public class Arc : Circle, ICurve<Arc>
+    public class Arc : Circle, IGeometry<Arc>
     {
         /// <summary>
         /// Initializes an arc from a plane, a radius and an angle domain expressed as an interval in radians.

--- a/src/GShark/Geometry/Circle.cs
+++ b/src/GShark/Geometry/Circle.cs
@@ -14,7 +14,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Geometry/CircleTests.cs?name=example)]
     /// </example>
-    public class Circle : NurbsBase, IEquatable<Circle>, ITransformable<Circle>
+    public class Circle : NurbsBase, ICurve<Circle>
     {
         internal Interval _domain = new Interval(0.0, 2.0 * Math.PI);
         internal double _length;

--- a/src/GShark/Geometry/Circle.cs
+++ b/src/GShark/Geometry/Circle.cs
@@ -14,7 +14,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Geometry/CircleTests.cs?name=example)]
     /// </example>
-    public class Circle : NurbsBase, ICurve<Circle>
+    public class Circle : NurbsBase, IGeometry<Circle>
     {
         internal Interval _domain = new Interval(0.0, 2.0 * Math.PI);
         internal double _length;

--- a/src/GShark/Geometry/Line.cs
+++ b/src/GShark/Geometry/Line.cs
@@ -11,7 +11,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Geometry/LineTests.cs?name=example)]
     /// </example>
-    public class Line : NurbsBase, IEquatable<Line>, ITransformable<Line>
+    public class Line : NurbsBase, ICurve<Line>
     {
         /// <summary>
         /// Initializes a line by start point and end point.

--- a/src/GShark/Geometry/Line.cs
+++ b/src/GShark/Geometry/Line.cs
@@ -11,7 +11,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Geometry/LineTests.cs?name=example)]
     /// </example>
-    public class Line : NurbsBase, ICurve<Line>
+    public class Line : NurbsBase, IGeometry<Line>
     {
         /// <summary>
         /// Initializes a line by start point and end point.

--- a/src/GShark/Geometry/NurbsBase.cs
+++ b/src/GShark/Geometry/NurbsBase.cs
@@ -9,13 +9,14 @@ using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
 using GShark.Optimization;
+using GShark.Interfaces;
 
 namespace GShark.Geometry
 {
     /// <summary>
     /// This class represents a base class that is common to most curve types.
     /// </summary>
-    public abstract class NurbsBase : IEquatable<NurbsBase>
+    public abstract class NurbsBase : IEquatable<NurbsBase>, ITransformable<NurbsBase>
     {
         protected NurbsBase()
         {
@@ -852,6 +853,12 @@ namespace GShark.Geometry
             }
 
             return sBldr.ToString().GetHashCode();
+        }
+
+        public NurbsBase Transform(TransformMatrix t)
+        {
+            Type type = GetType();
+            return type.GetMethod(nameof(Transform)).Invoke(this, new object[] { t }) as NurbsBase;
         }
     }
 }

--- a/src/GShark/Geometry/NurbsBase.cs
+++ b/src/GShark/Geometry/NurbsBase.cs
@@ -16,7 +16,7 @@ namespace GShark.Geometry
     /// <summary>
     /// This class represents a base class that is common to most curve types.
     /// </summary>
-    public abstract class NurbsBase : IEquatable<NurbsBase>, ITransformable<NurbsBase>
+    public abstract class NurbsBase : IGeometry<NurbsBase>
     {
         protected NurbsBase()
         {
@@ -176,7 +176,7 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// <inheritdoc cref="ICurve.PointAt"/>
+        /// <inheritdoc cref="IGeometry.PointAt"/>
         /// </summary>
         public virtual Point3 PointAt(double t)
         {
@@ -193,7 +193,7 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// <inheritdoc cref="ICurve.PointAtLength"/>
+        /// <inheritdoc cref="IGeometry.PointAtLength"/>
         /// </summary>
         public virtual Point3 PointAtLength(double length)
         {
@@ -386,7 +386,7 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// <inheritdoc cref="ICurve.ClosestPoint"/>
+        /// <inheritdoc cref="IGeometry.ClosestPoint"/>
         /// </summary>
         public virtual Point3 ClosestPoint(Point3 point)
         {
@@ -396,7 +396,7 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// <inheritdoc cref="ICurve.ClosestParameter"/>
+        /// <inheritdoc cref="IGeometry.ClosestParameter"/>
         /// </summary>
         public virtual double ClosestParameter(Point3 pt)
         {
@@ -424,7 +424,7 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// <inheritdoc cref="ICurve.LengthAt"/>
+        /// <inheritdoc cref="IGeometry.LengthAt"/>
         /// </summary>
         public virtual double LengthAt(double t)
         {
@@ -854,9 +854,15 @@ namespace GShark.Geometry
 
             return sBldr.ToString().GetHashCode();
         }
-
+        /// <summary>
+        /// Applies a transformation on the geometry object and returns the transformed geometry.
+        /// </summary>
+        /// <param name="t">The transformation matrix that represents the transformation.</param>
+        /// <returns>The transformed geometry</returns>
         public NurbsBase Transform(TransformMatrix t)
         {
+            // Figuring out the type of geometry using reflection so that the Transform function of that geometry 
+            // type is invoked.
             Type type = GetType();
             return type.GetMethod(nameof(Transform)).Invoke(this, new object[] { t }) as NurbsBase;
         }

--- a/src/GShark/Geometry/NurbsSurface.cs
+++ b/src/GShark/Geometry/NurbsSurface.cs
@@ -15,7 +15,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Data/NurbsSurfaceCollection.cs?name=example)]
     /// </example>
-    public class NurbsSurface : ICurve<NurbsSurface>
+    public class NurbsSurface : IGeometry<NurbsSurface>
     {
         /// <summary>
         /// Internal constructor used to validate the NURBS surface.

--- a/src/GShark/Geometry/NurbsSurface.cs
+++ b/src/GShark/Geometry/NurbsSurface.cs
@@ -15,7 +15,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Data/NurbsSurfaceCollection.cs?name=example)]
     /// </example>
-    public class NurbsSurface : IEquatable<NurbsSurface>, ITransformable<NurbsSurface>
+    public class NurbsSurface : ICurve<NurbsSurface>
     {
         /// <summary>
         /// Internal constructor used to validate the NURBS surface.

--- a/src/GShark/Geometry/Plane.cs
+++ b/src/GShark/Geometry/Plane.cs
@@ -10,7 +10,7 @@ namespace GShark.Geometry
     /// <summary>
     /// A plane is simply an origin point and normal.
     /// </summary>
-    public class Plane : ICurve<Plane>
+    public class Plane : IGeometry<Plane>
     {
         public Plane()
         {

--- a/src/GShark/Geometry/Plane.cs
+++ b/src/GShark/Geometry/Plane.cs
@@ -10,7 +10,7 @@ namespace GShark.Geometry
     /// <summary>
     /// A plane is simply an origin point and normal.
     /// </summary>
-    public class Plane : IEquatable<Plane>, ITransformable<Plane>
+    public class Plane : ICurve<Plane>
     {
         public Plane()
         {

--- a/src/GShark/Geometry/Polyline.cs
+++ b/src/GShark/Geometry/Polyline.cs
@@ -13,7 +13,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Geometry/PolylineTests.cs?name=example)]
     /// </example>
-    public class PolyLine : NurbsBase, IEquatable<PolyLine>, ITransformable<PolyLine>
+    public class PolyLine : NurbsBase, ICurve<PolyLine>
     {
         /// <summary>
         /// Initializes a new polyline from a collection of points.

--- a/src/GShark/Geometry/Polyline.cs
+++ b/src/GShark/Geometry/Polyline.cs
@@ -13,7 +13,7 @@ namespace GShark.Geometry
     /// <example>
     /// [!code-csharp[Example](../../src/GShark.Test.XUnit/Geometry/PolylineTests.cs?name=example)]
     /// </example>
-    public class PolyLine : NurbsBase, ICurve<PolyLine>
+    public class PolyLine : NurbsBase, IGeometry<PolyLine>
     {
         /// <summary>
         /// Initializes a new polyline from a collection of points.
@@ -162,7 +162,7 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// <inheritdoc cref="ICurve.PointAtLength"/>
+        /// <inheritdoc cref="IGeometry.PointAtLength"/>
         /// </summary>
         public override Point3 PointAtLength(double length)
         {

--- a/src/GShark/Interfaces/ICurve.cs
+++ b/src/GShark/Interfaces/ICurve.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GShark.Interfaces
+{
+    public interface ICurve<T> : IEquatable<T>, ITransformable<T>
+    {
+    }
+}

--- a/src/GShark/Interfaces/IGeometry.cs
+++ b/src/GShark/Interfaces/IGeometry.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace GShark.Interfaces
 {
-    public interface ICurve<T> : IEquatable<T>, ITransformable<T>
+    public interface IGeometry<T> : IEquatable<T>, ITransformable<T>
     {
     }
 }


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [x] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

### Description

This PR introduces ICurve interface in order to implement Transform function in NurbsBase. With these changes, one can
make a `List<NurbsBase> geometries` which can contain any transformable geometry and `geometries.Select(c => c.Transform(xForm)).ToList()` would execute the `Trasnform` function of each respective geometry.

### Related Tickets & Documents

Closes #383

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 docs
- [x] 🙅 no documentation needed
