### PR TITLE
fix NurbsBase.PerpendicularFrames

### DIFF
--- a/src/GShark.Test.XUnit/Sampling/CurveTests.cs
+++ b/src/GShark.Test.XUnit/Sampling/CurveTests.cs
@@ -299,6 +299,47 @@ namespace GShark.Test.XUnit.Sampling
         }
 
         [Fact]
+        public void It_Calculates_Rotation_Minimized_Frames_Along_Curve2()
+        {            
+            //Arrange
+            List<Point3> railPts = new List<Point3>()
+            {
+                new Point3(-0.9214326, -1.0785674, -7.991379E-08),
+                new Point3(-0.4986757, -0.79609025, -7.991379E-08),
+                new Point3(0, -0.6968975, -7.991379E-08),
+                new Point3(0.4986757, -0.79609036, -7.991379E-08),
+                new Point3(0.9214326, -1.0785673, -7.991379E-08)
+            };
+            List<Point3> profilePts = new List<Point3>()
+            {
+                new Point3(-0.29289323, -1.7071068, 0),
+                new Point3(-0.50000006, -1.5, 0.7071067),
+                new Point3(-1, -1, 0.99999994),
+                new Point3(-1.5, -0.50000006, 0.7071067),
+                new Point3(-1.7071067, -0.2928933, -8.742278E-08),
+                new Point3(-1.4999999, -0.50000006, -0.7071068),
+                new Point3(-1, -1, -0.99999994),
+                new Point3(-0.5000001, -1.4999998, -0.7071068),
+                new Point3(-0.29289323, -1.7071068, -3.0199158E-07)
+            };
+
+            var rail = new NurbsCurve(railPts, 1);
+            var profile = new NurbsCurve(profilePts, 1);
+
+            var sweepNurb = NurbsSurface.FromSweep(rail, profile);
+
+            var tValues = new [] { 0d, .25d, .5d, .75d, 1d }.ToList();       
+            List<Plane> frames = rail.PerpendicularFrames(tValues);
+
+            foreach (var frame in frames)
+            {                
+                frame.XAxis.Length.Should().BeApproximately(1, GSharkMath.MinTolerance);
+                frame.YAxis.Length.Should().BeApproximately(1, GSharkMath.MinTolerance);
+                frame.ZAxis.Length.Should().BeApproximately(1, GSharkMath.MinTolerance);                
+            }
+        }
+
+        [Fact]
         public void Return_Adaptive_Sample_Subdivision_Of_A_Nurbs()
         {
             // Arrange

--- a/src/GShark/GShark.csproj
+++ b/src/GShark/GShark.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <AssemblyName>GShark</AssemblyName>
     <RootNamespace>GShark</RootNamespace>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Sharker/G-Shark</RepositoryUrl>	

--- a/src/GShark/Geometry/NurbsBase.cs
+++ b/src/GShark/Geometry/NurbsBase.cs
@@ -615,9 +615,13 @@ namespace GShark.Geometry
         /// Double reflection method taken from Wang, W., J¨uttler, B., Zheng, D., and Liu, Y. 2008. "Computation of rotation minimizing frame."<br/>
         /// https://www.microsoft.com/en-us/research/wp-content/uploads/2016/12/Computation-of-rotation-minimizing-frames.pdf
         /// </summary>
-        ///<param name="uValues">The curve parameter values to locate perpendicular curve frames</param>
+        /// <param name="uValues">The curve parameter values to locate perpendicular curve frames</param>
+        /// <param name="startTangent">If not null override start tangent vector.</param>
+        /// <param name="endTangent">If not null override end tangent vector.</param>
         /// <returns>A collection of planes.</returns>
-        public List<Plane> PerpendicularFrames(List<double> uValues)
+        public List<Plane> PerpendicularFrames(List<double> uValues,
+            Vector3? startTangent = null,
+            Vector3? endTangent = null)
         {
             var pointsOnCurve = uValues.Select(PointAt).ToList(); //get points at t values
             var pointsOnCurveTan = uValues.Select(t => Evaluate.Curve.RationalDerivatives(this, t, 1)[1]).ToList(); //get tangents at t values
@@ -625,7 +629,7 @@ namespace GShark.Geometry
 
             //Create initial frame at first parameter
             var origin = PointAt(firstParameter);
-            var crvTan = Evaluate.Curve.RationalDerivatives(this, firstParameter, 1)[1];
+            var crvTan = startTangent is not null ? startTangent.Value : Evaluate.Curve.RationalDerivatives(this, firstParameter, 1)[1];
             var crvNormal = Vector3.PerpendicularTo(crvTan);
             var yAxis = Vector3.CrossProduct(crvTan, crvNormal);
             var xAxis = Vector3.CrossProduct(yAxis, crvTan);
@@ -659,6 +663,10 @@ namespace GShark.Geometry
                 var sNext = Vector3.CrossProduct(pointsOnCurveTan[i + 1], rNext); //compute vector s[i+1] of next frame
 
                 //create output frame
+                if (i == pointsOnCurve.Count - 2 && endTangent is not null)
+                {
+                    rNext = Vector3.CrossProduct(sNext, endTangent.Value);
+                }
                 var frameNext = new Plane(pointsOnCurve[i + 1], rNext, sNext);                
                 perpFrames[i + 1] = frameNext; //output frame
             }

--- a/src/GShark/Geometry/NurbsBase.cs
+++ b/src/GShark/Geometry/NurbsBase.cs
@@ -659,7 +659,7 @@ namespace GShark.Geometry
                 var sNext = Vector3.CrossProduct(pointsOnCurveTan[i + 1], rNext); //compute vector s[i+1] of next frame
 
                 //create output frame
-                var frameNext = new Plane { Origin = pointsOnCurve[i + 1], XAxis = rNext, YAxis = sNext };
+                var frameNext = new Plane(pointsOnCurve[i + 1], rNext, sNext);                
                 perpFrames[i + 1] = frameNext; //output frame
             }
 

--- a/src/GShark/Geometry/NurbsSurface.cs
+++ b/src/GShark/Geometry/NurbsSurface.cs
@@ -269,11 +269,15 @@ namespace GShark.Geometry
         /// </summary>
         /// <param name="rail">The rail curve.</param>
         /// <param name="profile">The section curve.</param>
+        /// <param name="startTangent">If not null override start tangent vector.</param>
+        /// <param name="endTangent">If not null override end tangent vector.</param>
         /// <returns>The sweep surface.</returns>
-        public static NurbsSurface FromSweep(NurbsBase rail, NurbsBase profile)
+        public static NurbsSurface FromSweep(NurbsBase rail, NurbsBase profile,
+            Vector3? startTangent = null,
+            Vector3? endTangent = null)
         {
             var (tValues, _) = Sampling.Curve.AdaptiveSample(rail, GSharkMath.MaxTolerance);
-            List<Plane> frames = rail.PerpendicularFrames(tValues);
+            List<Plane> frames = rail.PerpendicularFrames(tValues, startTangent, endTangent);
             List<NurbsBase> curves = new List<NurbsBase> {profile};
 
             for (int i = 1; i < frames.Count; i++)


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix

### Description

This PR fixes PerpendicularFrames ensuring resulting xaxis, yaxis, zaxis normalized.

### Related Tickets & Documents

I added repro example to see the behavior in follows:

```sh
git clone -b dev/devel0/fix-perp-frames-sample https://github.com/SearchAThing-forks/G-Shark.git
cd G-Shark/examples/example-0022
```

1) **without fix perp frames**

```sh
git checkout bf6dd663285200e0646dc8db87c349d5a371dceb
dotnet run
```

![image](https://user-images.githubusercontent.com/13405008/231617518-68761b0b-de83-4c7e-bc8d-62885619eecc.png)

2) **with fix perp frames**

```sh
git checkout 49f86051c8f844647815d4aa576f1104db6401ae
dotnet run
```

![image](https://user-images.githubusercontent.com/13405008/231617799-ee1c15b3-6294-44ed-8fbb-79c02aab98da.png)

3) **with few rails points**

```sh
git checkout 9df7fcb34dcffe7d79ce410a2849c3d879cfda2f
dotnet run
```

![image](https://user-images.githubusercontent.com/13405008/231617990-af917d9b-ffae-4d13-97e3-dfed0247c9ca.png)

(press 'space' to toggle joint visibility)

![image](https://user-images.githubusercontent.com/13405008/231618183-10a12cff-37ec-469d-a724-8cb422215438.png)

notice inner Xaxis(red) of planes = Yaxis(green) x Zaxis(blue) these are all increased of a quantity that is the difference between first tangent ( not exactly normal to the start plane ) and the effective normal. If you increase the nr. of rail pts ( see (2) from 4 to 40 ) the problem reduces but its the same and cause not exact closure to target tube.
For this type of problem I didn't find a solution yet but I report the observation on that.

### Added tests?

- [X] 👍 yes

`It_Calculates_Rotation_Minimized_Frames_Along_Curve2`

### Added to documentation?

- [X ] 🙅 no documentation needed
